### PR TITLE
make prettyPrintStackTrace to ruby standards.

### DIFF
--- a/logstash/inputs/log4j2.rb
+++ b/logstash/inputs/log4j2.rb
@@ -67,15 +67,15 @@ class LogStash::Inputs::Log4j2 < LogStash::Inputs::Base
   end # def register
 
   private 
-  def prettyPrintEntireStackTrace(proxy)
-    indentation = "\n\t"                
-    a = proxy.getName + " " + proxy.getMessage.to_s + indentation
-    a += proxy.getExtendedStackTrace.to_a.join(indentation)
-    while (b = proxy.getCauseProxy)
-      a += "\nCaused by: " + b.getName + " " + b.getMessage + indentation + b.getExtendedStackTrace.to_a.join(indentation)
-      proxy = b 
+  def pretty_print_stack_trace(proxy)
+    indentation = "\n\t"
+    result = "#{proxy.getName}: #{proxy.getMessage.to_s}#{indentation}#{proxy.getExtendedStackTrace.to_a.join(indentation)}"
+    cause = proxy.getCauseProxy
+    while cause
+      result += "\nCaused by: #{cause.getName}: #{cause.getMessage.to_s}#{indentation}#{cause.getExtendedStackTrace.to_a.join(indentation)}"
+      cause = cause.getCauseProxy
     end        
-    return a
+    result
   end
 
   private


### PR DESCRIPTION
just renamed the function to ruby standards. There was one more place where getMessage was passed to to_s
