### PR TITLE
supporting logstash 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 gemspec
-gem "logstash", :github => "elasticsearch/logstash", :branch => "1.5"
+#gem "logstash", :github => "elastic/logstash", :branch => "2.1"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 gemspec
-#gem "logstash", :github => "elastic/logstash", :branch => "2.1"
+gem "logstash", :github => "elastic/logstash", :branch => "2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,89 @@
+PATH
+  remote: .
+  specs:
+    logstash-input-log4j2 (5.2-java)
+      logstash-core (>= 2.0.0.beta2, < 3.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cabin (0.7.2)
+    clamp (0.6.5)
+    coderay (1.1.0)
+    concurrent-ruby (0.9.2-java)
+    diff-lcs (1.2.5)
+    ffi (1.9.10-java)
+    filesize (0.0.4)
+    gem_publisher (1.5.0)
+    gems (0.8.3)
+    i18n (0.6.9)
+    insist (1.0.0)
+    jrjackson (0.3.7)
+    jruby-openssl (0.9.12-java)
+    kramdown (1.9.0)
+    logstash-core (2.1.1-java)
+      cabin (~> 0.7.0)
+      clamp (~> 0.6.5)
+      concurrent-ruby (= 0.9.2)
+      filesize (= 0.0.4)
+      gems (~> 0.8.3)
+      i18n (= 0.6.9)
+      jrjackson (~> 0.3.7)
+      jruby-openssl (>= 0.9.11)
+      minitar (~> 0.5.4)
+      pry (~> 0.10.1)
+      rubyzip (~> 1.1.7)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.5)
+      treetop (< 1.5.0)
+    logstash-devutils (0.0.18-java)
+      gem_publisher
+      insist (= 1.0.0)
+      kramdown
+      minitar
+      rake
+      rspec (~> 3.1.0)
+      rspec-wait
+      stud (>= 0.0.20)
+    method_source (0.8.2)
+    minitar (0.5.4)
+    polyglot (0.3.5)
+    pry (0.10.3-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    rake (10.4.2)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    rspec-wait (0.0.8)
+      rspec (>= 2.11, < 3.5)
+    rubyzip (1.1.7)
+    slop (3.6.0)
+    spoon (0.0.4)
+      ffi
+    stud (0.0.22)
+    thread_safe (0.3.5-java)
+    treetop (1.4.15)
+      polyglot
+      polyglot (>= 0.3.1)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  logstash-devutils
+  logstash-input-log4j2!
+
+BUNDLED WITH
+   1.10.6

--- a/logstash-input-log4j2.gemspec
+++ b/logstash-input-log4j2.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-input-log4j2'
-  s.version         = '5.1'
+  s.version         = '5.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events over a TCP socket from a Log4j2 SocketAppender"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -11,7 +10,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = `git ls-files`.split($\)+::Dir.glob('vendor/*')
+  #s.files = `git ls-files`.split($\)+::Dir.glob('vendor/*')
+
+
+  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
@@ -21,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.platform = 'java'
 
-  s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
+
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
I noticed that the current version doesn't work with logstash 2.1 and there are some minor fixes that'd make it work. 
Also, I didn't need to include the `gem "logstash"` line to make it work either, merged it back in though.
Additionally, the directory had to be named `logstash-input-log4j2` for it to install/build